### PR TITLE
Feature/#40

### DIFF
--- a/src/sorting.ts
+++ b/src/sorting.ts
@@ -2,6 +2,14 @@
 
 import { validArray, validString } from './validation';
 import { Import } from './models/import';
+import {
+  determineForwardHierarchyLevel,
+  normalizePath,
+  isBackwardsPath,
+  isCurrentPath,
+  startsWithAT,
+  isLibrary,
+} from './util';
 
 /** used for Array.sort */
 const FIRST_AFTER_SECOND = 1;
@@ -14,9 +22,6 @@ const INVALID_OR_ERROR = 0;
 
 const FOLDER_PATH = '../';
 const FOLDER_PATH_REGEX = new RegExp(FOLDER_PATH, 'g');
-
-// the regex is matching '/'
-const PATH_SEPARATOR_REGEX = /\//g;
 
 export function sort(imports: Import[]): Import[] {
   if (!validArray(imports)) {
@@ -138,38 +143,6 @@ function sortAT(first: string, second: string): number {
   return FIRST_EQUALS_SECOND;
 }
 
-function startsWithAT(statement: string): boolean {
-  if (!validString(statement)) {
-    return false;
-  }
-
-  return isFirstCharacter(statement, '@');
-}
-
-function isRelativePath(statement: string): boolean {
-  if (!validString(statement)) {
-    return false;
-  }
-
-  return isFirstCharacter(statement, '.') || isFirstCharacter(statement, '/');
-}
-
-function isFirstCharacter(statement: string, char: string): boolean {
-  if (!validString(statement) || !validString(char)) {
-    return false;
-  }
-
-  return statement.charAt(0) === char;
-}
-
-function isLibrary(statement: string): boolean {
-  if (!validString(statement)) {
-    return false;
-  }
-
-  return startsWithAT(statement) || !isRelativePath(statement);
-}
-
 function sortLibraries(first: string, second: string): number {
   if (!validString(first) || !validString(second)) {
     return INVALID_OR_ERROR;
@@ -247,41 +220,6 @@ function handleForwardPath(first: string, second: string): number {
 
   // TODO: this should never happen
   return INVALID_OR_ERROR;
-}
-
-function normalizePath(statement: string): string {
-  if (!validString(statement)) {
-    return statement;
-  }
-
-  if (isFirstCharacter(statement, '.') && statement.charAt(1) === '/') {
-    return statement.slice(2);
-  }
-  return statement;
-}
-
-function isBackwardsPath(statement: string): boolean {
-  if (!validString(statement)) {
-    return false;
-  }
-
-  return statement.startsWith(FOLDER_PATH);
-}
-
-function isForwardPath(statement: string): boolean {
-  if (!validString) {
-    return false;
-  }
-
-  return !isBackwardsPath(statement) && !isCurrentPath(statement);
-}
-
-function isCurrentPath(statement: string): boolean {
-  if (!validString(statement)) {
-    return false;
-  }
-
-  return determineForwardHierarchyLevel(statement) === 0;
 }
 
 // TODO convert first to lowercase, so that we have a case-insensitive sorting?
@@ -362,15 +300,10 @@ function handleBothForwardPaths(first: string, second: string): number {
   return FIRST_AFTER_SECOND;
 }
 
-function determineForwardHierarchyLevel(statement: string): number {
-  if (!validString(statement)) {
-    return -1;
+function isForwardPath(statement: string): boolean {
+  if (!validString) {
+    return false;
   }
 
-  const match = statement.match(PATH_SEPARATOR_REGEX);
-  if (match) {
-    return match.length;
-  }
-
-  return 0;
+  return !isBackwardsPath(statement) && !isCurrentPath(statement);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,82 @@
 'use strict';
 
+import { validString } from './validation';
+
+const FOLDER_PATH = '../';
+const PATH_SEPARATOR_REGEX = /\//g;
+
 export function isLastIteration<T>(i: number, anArray: Array<T>): boolean {
   return i === anArray.length - 1;
+}
+
+export function isLibrary(statement: string): boolean {
+  if (!validString(statement)) {
+    return false;
+  }
+
+  return startsWithAT(statement) || !isRelativePath(statement);
+}
+
+export function normalizePath(statement: string): string {
+  if (!validString(statement)) {
+    return statement;
+  }
+
+  if (isFirstCharacter(statement, '.') && statement.charAt(1) === '/') {
+    return statement.slice(2);
+  }
+  return statement;
+}
+
+export function isBackwardsPath(statement: string): boolean {
+  if (!validString(statement)) {
+    return false;
+  }
+
+  return statement.startsWith(FOLDER_PATH);
+}
+
+export function isCurrentPath(statement: string): boolean {
+  if (!validString(statement)) {
+    return false;
+  }
+
+  return determineForwardHierarchyLevel(statement) === 0;
+}
+
+export function determineForwardHierarchyLevel(statement: string): number {
+  if (!validString(statement)) {
+    return -1;
+  }
+
+  const match = statement.match(PATH_SEPARATOR_REGEX);
+  if (match) {
+    return match.length;
+  }
+
+  return 0;
+}
+
+export function startsWithAT(statement: string): boolean {
+  if (!validString(statement)) {
+    return false;
+  }
+
+  return isFirstCharacter(statement, '@');
+}
+
+function isRelativePath(statement: string): boolean {
+  if (!validString(statement)) {
+    return false;
+  }
+
+  return isFirstCharacter(statement, '.') || isFirstCharacter(statement, '/');
+}
+
+function isFirstCharacter(statement: string, char: string): boolean {
+  if (!validString(statement) || !validString(char)) {
+    return false;
+  }
+
+  return statement.charAt(0) === char;
 }


### PR DESCRIPTION
At this time the grouping for relative imports is not opinionated. They are split in three groups, back, current and forward but within these groups there are no particular rules at the moment.